### PR TITLE
0.5.3: Fix enum serializer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maktouch/kysely-zod-codegen",
-  "version": "0.5.0",
+  "version": "0.5.3",
   "author": "Makara Sok",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/src/serializer/serializer.ts
+++ b/src/serializer/serializer.ts
@@ -675,7 +675,12 @@ export class Serializer {
   serializeUnionExpressionZod(node: UnionExpressionNode) {
 
     if (node.args.length === 2) {
-      return this.serializeNullableExpressionZod(node)
+      const [_first, second] = node.args;
+
+      // Only use nullable serialization if the second argument is actually null
+      if (second && second.type === 'Identifier' && second.name === 'null') {
+        return this.serializeNullableExpressionZod(node);
+      }
     }
 
     let data = 'z.enum([';


### PR DESCRIPTION
Before:

```
| Enum Type                        | Expected Zod Output       | Actual Zod Output     | Status   |
|----------------------------------|---------------------------|-----------------------|----------|
| 2-option enum: ['owner','admin'] | z.enum(["owner","admin"]) | 'admin'               | ❌ BROKEN |
| 3-option enum: ['a','b','c']     | z.enum(["a","b","c"])     | z.enum(["a","b","c"]) | ✅ Working |
| Nullable: ['admin', null]        | 'admin'.nullish()         | 'admin'.nullish()     | ✅ Working |
```

After:

```
| Enum Type                        | Zod Output                | Status          |
|----------------------------------|---------------------------|-----------------|
| 2-option enum: ['owner','admin'] | z.enum(["admin","owner"]) | ✅ FIXED         |
| 3-option enum: ['a','b','c']     | z.enum(["a","b","c"])     | ✅ Still working |
| Nullable: ['admin', null]        | 'admin'.nullish()         | ✅ Still working |
```