### PR TITLE
Added missing spatial types (Point, LineString, Polygon) to Zod serializer

### DIFF
--- a/src/dialects/postgres/postgres-introspector.ts
+++ b/src/dialects/postgres/postgres-introspector.ts
@@ -23,6 +23,14 @@ type PostgresDomainInspector = {
 export class PostgresIntrospector extends Introspector<PostgresDB> {
   readonly adapter: PostgresAdapter;
 
+  private readonly POSTGIS_SYSTEM_TABLES = new Set([
+    'geography_columns',
+    'geometry_columns',
+    'spatial_ref_sys',
+  ]);
+
+  private readonly POSTGIS_SCHEMAS = new Set(['tiger', 'topology']);
+
   constructor(adapter: PostgresAdapter) {
     super();
     this.adapter = adapter;
@@ -127,15 +135,9 @@ export class PostgresIntrospector extends Introspector<PostgresDB> {
   async introspect(options: IntrospectOptions<PostgresDB>) {
     const tables = await this.getTables(options);
 
-    const postgisSystemTables = ['geography_columns', 'geometry_columns', 'spatial_ref_sys'];
     const filteredTables = tables.filter(({ name, schema }) => {
-      if (schema === 'public' && postgisSystemTables.includes(name)) {
-        return false;
-      }
-
-      if (schema === 'tiger' || schema === 'topology') {
-        return false;
-      }
+      if (schema === 'public' && this.POSTGIS_SYSTEM_TABLES.has(name)) return false;
+      if (schema && this.POSTGIS_SCHEMAS.has(schema)) return false;
 
       return true;
     });

--- a/src/dialects/postgres/postgres-introspector.ts
+++ b/src/dialects/postgres/postgres-introspector.ts
@@ -126,10 +126,24 @@ export class PostgresIntrospector extends Introspector<PostgresDB> {
 
   async introspect(options: IntrospectOptions<PostgresDB>) {
     const tables = await this.getTables(options);
+
+    const postgisSystemTables = ['geography_columns', 'geometry_columns', 'spatial_ref_sys'];
+    const filteredTables = tables.filter(({ name, schema }) => {
+      if (schema === 'public' && postgisSystemTables.includes(name)) {
+        return false;
+      }
+
+      if (schema === 'tiger' || schema === 'topology') {
+        return false;
+      }
+
+      return true;
+    });
+
     const [enums, domains] = await Promise.all([
       this.#introspectEnums(options.db),
       this.#introspectDomains(options.db),
     ]);
-    return this.#createDatabaseMetadata(tables, enums, domains);
+    return this.#createDatabaseMetadata(filteredTables, enums, domains);
   }
 }

--- a/src/serializer/serializer.ts
+++ b/src/serializer/serializer.ts
@@ -519,6 +519,12 @@ export class Serializer {
         return 'z.coerce.date()';
       case 'undefined':
         return '.optional()';
+      case 'LineString':
+        return 'z.array(z.object({ x: z.coerce.number(), y: z.coerce.number() }))';
+      case 'Point':
+        return 'z.object({ x: z.coerce.number(), y: z.coerce.number() })';
+      case 'Polygon':
+        return 'z.array(z.array(z.object({ x: z.coerce.number(), y: z.coerce.number() })))';
     }
     return node.name;
   }

--- a/src/serializer/serializer.ts
+++ b/src/serializer/serializer.ts
@@ -30,16 +30,47 @@ export type SerializerOptions = {
  */
 export class Serializer {
   readonly typeOnlyImports: boolean;
+  private serializableTypeNames: Set<string> = new Set();
 
   constructor(options: SerializerOptions = {}) {
     this.typeOnlyImports = options.typeOnlyImports ?? true;
   }
 
   serialize(nodes: StatementNode[]) {
+    this.serializableTypeNames.clear();
+
+    for (const node of nodes) {
+      if (node.type === NodeType.EXPORT_STATEMENT &&
+          node.argument.type === NodeType.ALIAS_DECLARATION) {
+
+        const expression = node.argument.body.type === NodeType.TEMPLATE
+        ? node.argument.body.expression
+        : node.argument.body;
+
+        if (this.serializableTypeNames.has(node.argument.name)) continue;
+
+        if (this.isSerializableToZod(expression, nodes)) {
+          this.serializableTypeNames.add(node.argument.name);
+        }
+      }
+    }
+
+    const sortedNodes = [...nodes].sort((a, b) => {
+      if (a.type !== NodeType.EXPORT_STATEMENT || b.type !== NodeType.EXPORT_STATEMENT) return 0;
+      if (a.argument.type !== NodeType.ALIAS_DECLARATION || b.argument.type !== NodeType.ALIAS_DECLARATION) return 0;
+
+      const aExpr = a.argument.body.type === NodeType.TEMPLATE ? a.argument.body.expression : a.argument.body;
+      const bExpr = b.argument.body.type === NodeType.TEMPLATE ? b.argument.body.expression : b.argument.body;
+
+      if (aExpr.type === NodeType.OBJECT_EXPRESSION && bExpr.type === NodeType.ARRAY_EXPRESSION) return -1;
+      if (aExpr.type === NodeType.ARRAY_EXPRESSION && bExpr.type === NodeType.OBJECT_EXPRESSION) return 1;
+      return 0;
+    });
+
     let data = '';
     let i = 0;
 
-    for (const node of nodes) {
+    for (const node of sortedNodes) {
       if (i >= 1) {
         data += '\n';
 
@@ -406,7 +437,15 @@ export class Serializer {
 
     switch (node.argument.type) {
       case NodeType.ALIAS_DECLARATION:
-        data += this.serializeAliasDeclarationZod(node.argument);
+        const expression = node.argument.body.type === NodeType.TEMPLATE
+          ? node.argument.body.expression
+          : node.argument.body;
+
+        if (this.isSerializableToZod(expression)) {
+          data += this.serializeAliasDeclarationZod(node.argument);
+        } else {
+          return '';
+        }
         break;
       case NodeType.INTERFACE_DECLARATION:
         data += this.serializeInterfaceDeclarationZod(node.argument);
@@ -414,6 +453,70 @@ export class Serializer {
     }
 
     return data;
+  }
+
+  isSerializableToZod(node: ExpressionNode, allNodes?: StatementNode[]): boolean {
+    switch (node.type) {
+      case NodeType.OBJECT_EXPRESSION:
+        return true;
+      case NodeType.ARRAY_EXPRESSION:
+        const arrayElement = (node as ArrayExpressionNode).values;
+        if (arrayElement.type === NodeType.IDENTIFIER) {
+          const name = (arrayElement as IdentifierNode).name;
+          const zodResult = this.serializeIdentifierZod(arrayElement as IdentifierNode);
+
+          if (zodResult.startsWith('z.') || zodResult === '.optional()') return true;
+          if (this.serializableTypeNames.has(name)) return true;
+
+          if (allNodes) {
+            const referencedNode = allNodes.find(n =>
+              n.type === NodeType.EXPORT_STATEMENT &&
+              (n as ExportStatementNode).argument.type === NodeType.ALIAS_DECLARATION &&
+              (n as ExportStatementNode).argument.name === name
+            ) as ExportStatementNode | undefined;
+
+            if (referencedNode && referencedNode.argument.type === NodeType.ALIAS_DECLARATION) {
+              const refExpr = referencedNode.argument.body.type === NodeType.TEMPLATE
+                ? referencedNode.argument.body.expression
+                : referencedNode.argument.body;
+              return this.isSerializableToZod(refExpr, allNodes);
+            }
+          }
+
+          return false;
+        }
+        return this.isSerializableToZod(arrayElement, allNodes);
+      case NodeType.IDENTIFIER:
+        const name = (node as IdentifierNode).name;
+        const zodResult = this.serializeIdentifierZod(node as IdentifierNode);
+        if (zodResult.startsWith('z.') || zodResult === '.optional()') return true;
+        if (this.serializableTypeNames.has(name)) return true;
+
+        if (allNodes) {
+          const referencedNode = allNodes.find(n =>
+            n.type === NodeType.EXPORT_STATEMENT &&
+            (n as ExportStatementNode).argument.type === NodeType.ALIAS_DECLARATION &&
+            (n as ExportStatementNode).argument.name === name
+          ) as ExportStatementNode | undefined;
+
+          if (referencedNode && referencedNode.argument.type === NodeType.ALIAS_DECLARATION) {
+            const refExpr = referencedNode.argument.body.type === NodeType.TEMPLATE
+              ? referencedNode.argument.body.expression
+              : referencedNode.argument.body;
+            return this.isSerializableToZod(refExpr, allNodes);
+          }
+        }
+
+        return false;
+      case NodeType.LITERAL:
+        return true;
+      case NodeType.UNION_EXPRESSION:
+      case NodeType.GENERIC_EXPRESSION:
+      case NodeType.EXTENDS_CLAUSE:
+      case NodeType.MAPPED_TYPE:
+      case NodeType.INFER_CLAUSE:
+        return false;
+    }
   }
 
   serializeExpressionZod(node: ExpressionNode) {
@@ -520,8 +623,6 @@ export class Serializer {
         return 'z.coerce.date()';
       case 'undefined':
         return '.optional()';
-      case 'Point':
-        return 'point';
     }
     return node.name;
   }

--- a/src/serializer/serializer.ts
+++ b/src/serializer/serializer.ts
@@ -36,36 +36,95 @@ export class Serializer {
     this.typeOnlyImports = options.typeOnlyImports ?? true;
   }
 
-  serialize(nodes: StatementNode[]) {
+  getExpression(node: AliasDeclarationNode): ExpressionNode {
+    return node.body.type === NodeType.TEMPLATE
+    ? node.body.expression
+    : node.body;
+  }
+
+  collectSerializableTypes(nodes: StatementNode[]): void {
     this.serializableTypeNames.clear();
 
     for (const node of nodes) {
-      if (node.type === NodeType.EXPORT_STATEMENT &&
-          node.argument.type === NodeType.ALIAS_DECLARATION) {
+      if (node.type !== NodeType.EXPORT_STATEMENT) continue;
+      if (node.argument.type !== NodeType.ALIAS_DECLARATION) continue;
 
-        const expression = node.argument.body.type === NodeType.TEMPLATE
-        ? node.argument.body.expression
-        : node.argument.body;
+      if (this.serializableTypeNames.has(node.argument.name)) continue;
 
-        if (this.serializableTypeNames.has(node.argument.name)) continue;
+      const expression = this.getExpression(node.argument);
 
-        if (this.isSerializableToZod(expression, nodes)) {
-          this.serializableTypeNames.add(node.argument.name);
-        }
+      if (this.isSerializableToZod(expression, nodes)) {
+        this.serializableTypeNames.add(node.argument.name);
       }
     }
+  }
 
-    const sortedNodes = [...nodes].sort((a, b) => {
-      if (a.type !== NodeType.EXPORT_STATEMENT || b.type !== NodeType.EXPORT_STATEMENT) return 0;
-      if (a.argument.type !== NodeType.ALIAS_DECLARATION || b.argument.type !== NodeType.ALIAS_DECLARATION) return 0;
+  sortNodesByDependency(nodes: StatementNode[]): StatementNode[] {
+    return [...nodes].sort((a, b) => {
+      if (a.type !== NodeType.EXPORT_STATEMENT ||
+          b.type !== NodeType.EXPORT_STATEMENT ||
+          a.argument.type !== NodeType.ALIAS_DECLARATION ||
+          b.argument.type !== NodeType.ALIAS_DECLARATION) {
+        return 0;
+      }
 
-      const aExpr = a.argument.body.type === NodeType.TEMPLATE ? a.argument.body.expression : a.argument.body;
-      const bExpr = b.argument.body.type === NodeType.TEMPLATE ? b.argument.body.expression : b.argument.body;
+      const aExpr = this.getExpression(a.argument);
+      const bExpr = this.getExpression(b.argument);
 
       if (aExpr.type === NodeType.OBJECT_EXPRESSION && bExpr.type === NodeType.ARRAY_EXPRESSION) return -1;
       if (aExpr.type === NodeType.ARRAY_EXPRESSION && bExpr.type === NodeType.OBJECT_EXPRESSION) return 1;
+
       return 0;
-    });
+    })
+  }
+
+  findAliasDeclaration(nodes: StatementNode[], name: string): AliasDeclarationNode | undefined {
+    for (const node of nodes) {
+      if (node.type !== NodeType.EXPORT_STATEMENT) continue;
+      if (node.argument.type !== NodeType.ALIAS_DECLARATION) continue;
+      if (node.argument.name === name) {
+        return node.argument;
+      }
+    }
+    return undefined;
+  }
+
+  isSerializableToZod(node: ExpressionNode, allNodes?: StatementNode[]): boolean {
+    switch (node.type) {
+      case NodeType.OBJECT_EXPRESSION:
+        return true;
+      case NodeType.ARRAY_EXPRESSION:
+        return this.isSerializableToZod((node as ArrayExpressionNode).values, allNodes);
+      case NodeType.IDENTIFIER:
+        const name = (node as IdentifierNode).name;
+        if (this.serializableTypeNames.has(name)) return true;
+
+        const zodResult = this.serializeIdentifierZod(node as IdentifierNode);
+        if (zodResult.startsWith('z.') || zodResult === '.optional()') return true;
+
+        if (allNodes) {
+          const referencedAlias = this.findAliasDeclaration(allNodes, name);
+
+          if (referencedAlias) {
+            const refExpr = this.getExpression(referencedAlias);
+            return this.isSerializableToZod(refExpr, allNodes);
+          }
+        }
+        return false;
+      case NodeType.LITERAL:
+        return true;
+      case NodeType.UNION_EXPRESSION:
+      case NodeType.GENERIC_EXPRESSION:
+      case NodeType.EXTENDS_CLAUSE:
+      case NodeType.MAPPED_TYPE:
+      case NodeType.INFER_CLAUSE:
+        return false;
+    }
+  }
+
+  serialize(nodes: StatementNode[]) {
+    this.collectSerializableTypes(nodes);
+    const sortedNodes = this.sortNodesByDependency(nodes);
 
     let data = '';
     let i = 0;
@@ -82,7 +141,7 @@ export class Serializer {
       switch (node.type) {
         case NodeType.EXPORT_STATEMENT:
           data += this.serializeExportStatementZod(node);
-          data += '\n'
+          data += '\n';
           data += this.serializeExportStatement(node);
           break;
         case NodeType.IMPORT_STATEMENT:
@@ -437,9 +496,7 @@ export class Serializer {
 
     switch (node.argument.type) {
       case NodeType.ALIAS_DECLARATION:
-        const expression = node.argument.body.type === NodeType.TEMPLATE
-          ? node.argument.body.expression
-          : node.argument.body;
+        const expression = this.getExpression(node.argument);
 
         if (this.isSerializableToZod(expression)) {
           data += this.serializeAliasDeclarationZod(node.argument);
@@ -453,70 +510,6 @@ export class Serializer {
     }
 
     return data;
-  }
-
-  isSerializableToZod(node: ExpressionNode, allNodes?: StatementNode[]): boolean {
-    switch (node.type) {
-      case NodeType.OBJECT_EXPRESSION:
-        return true;
-      case NodeType.ARRAY_EXPRESSION:
-        const arrayElement = (node as ArrayExpressionNode).values;
-        if (arrayElement.type === NodeType.IDENTIFIER) {
-          const name = (arrayElement as IdentifierNode).name;
-          const zodResult = this.serializeIdentifierZod(arrayElement as IdentifierNode);
-
-          if (zodResult.startsWith('z.') || zodResult === '.optional()') return true;
-          if (this.serializableTypeNames.has(name)) return true;
-
-          if (allNodes) {
-            const referencedNode = allNodes.find(n =>
-              n.type === NodeType.EXPORT_STATEMENT &&
-              (n as ExportStatementNode).argument.type === NodeType.ALIAS_DECLARATION &&
-              (n as ExportStatementNode).argument.name === name
-            ) as ExportStatementNode | undefined;
-
-            if (referencedNode && referencedNode.argument.type === NodeType.ALIAS_DECLARATION) {
-              const refExpr = referencedNode.argument.body.type === NodeType.TEMPLATE
-                ? referencedNode.argument.body.expression
-                : referencedNode.argument.body;
-              return this.isSerializableToZod(refExpr, allNodes);
-            }
-          }
-
-          return false;
-        }
-        return this.isSerializableToZod(arrayElement, allNodes);
-      case NodeType.IDENTIFIER:
-        const name = (node as IdentifierNode).name;
-        const zodResult = this.serializeIdentifierZod(node as IdentifierNode);
-        if (zodResult.startsWith('z.') || zodResult === '.optional()') return true;
-        if (this.serializableTypeNames.has(name)) return true;
-
-        if (allNodes) {
-          const referencedNode = allNodes.find(n =>
-            n.type === NodeType.EXPORT_STATEMENT &&
-            (n as ExportStatementNode).argument.type === NodeType.ALIAS_DECLARATION &&
-            (n as ExportStatementNode).argument.name === name
-          ) as ExportStatementNode | undefined;
-
-          if (referencedNode && referencedNode.argument.type === NodeType.ALIAS_DECLARATION) {
-            const refExpr = referencedNode.argument.body.type === NodeType.TEMPLATE
-              ? referencedNode.argument.body.expression
-              : referencedNode.argument.body;
-            return this.isSerializableToZod(refExpr, allNodes);
-          }
-        }
-
-        return false;
-      case NodeType.LITERAL:
-        return true;
-      case NodeType.UNION_EXPRESSION:
-      case NodeType.GENERIC_EXPRESSION:
-      case NodeType.EXTENDS_CLAUSE:
-      case NodeType.MAPPED_TYPE:
-      case NodeType.INFER_CLAUSE:
-        return false;
-    }
   }
 
   serializeExpressionZod(node: ExpressionNode) {

--- a/src/serializer/serializer.ts
+++ b/src/serializer/serializer.ts
@@ -406,7 +406,8 @@ export class Serializer {
 
     switch (node.argument.type) {
       case NodeType.ALIAS_DECLARATION:
-        return ''
+        data += this.serializeAliasDeclarationZod(node.argument);
+        break;
       case NodeType.INTERFACE_DECLARATION:
         data += this.serializeInterfaceDeclarationZod(node.argument);
         break;
@@ -519,12 +520,8 @@ export class Serializer {
         return 'z.coerce.date()';
       case 'undefined':
         return '.optional()';
-      case 'LineString':
-        return 'z.array(z.object({ x: z.coerce.number(), y: z.coerce.number() }))';
       case 'Point':
-        return 'z.object({ x: z.coerce.number(), y: z.coerce.number() })';
-      case 'Polygon':
-        return 'z.array(z.array(z.object({ x: z.coerce.number(), y: z.coerce.number() })))';
+        return 'point';
     }
     return node.name;
   }
@@ -581,7 +578,7 @@ export class Serializer {
 
     data += 'const ';
     data += node.name;
-    data += ' ';
+    data += ' = ';
     data += this.serializeObjectExpressionZod(node.body);
 
     return data;
@@ -608,7 +605,7 @@ export class Serializer {
   serializeObjectExpressionZod(node: ObjectExpressionNode) {
     let data = '';
 
-    data += '= z.object({';
+    data += 'z.object({';
 
     if (node.properties.length) {
       data += '\n';


### PR DESCRIPTION
This PR adds Zod schema generation for custom database types (e.g., Point, LineString, Polygon) and automatically excludes PostGIS system tables from introspection.
Changes

1. Zod schema generation for custom types
-Fixed double = bug in Zod serialization for alias declarations
-Enabled Zod schema generation for custom type alias declarations (previously only TypeScript types were generated)
-Implemented dependency-aware serialization to ensure correct ordering (e.g., Point before LineString before Polygon)
-Fixed casing mismatch: type names (PascalCase) are converted to camelCase for Zod variable names (e.g., Point → point)

2. Type filtering logic
-Added isSerializableToZod() helper to distinguish serializable types from TypeScript-only types
-Implemented two-pass serialization: first pass collects serializable types, second pass generates schemas
-Prevents generating Zod schemas for TypeScript-only types like ColumnType, Generated, JsonPrimitive, JsonValue, etc.
-Made the logic generic and future-proof, removing hardcoded type checks

3. PostgreSQL system table exclusion
-Automatically excludes PostGIS system metadata tables (geography_columns, geometry_columns, spatial_ref_sys) from introspection
-Excludes PostGIS extension schemas (tiger, topology) by default
Users can still include these tables via --include-pattern if needed

Technical Details
-Serializer: Enhanced serializeAliasDeclarationZod() and serializeIdentifierZod() to handle custom types dynamically
-Postgres Introspector: Added filtering logic in introspect() to exclude system tables and extension schemas
-Dependency sorting: Ensures types are defined before they're referenced in generated Zod schemas