### PR TITLE
chore: bump package version to 0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maktouch/kysely-zod-codegen",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "author": "Makara Sok",
   "license": "MIT",
   "main": "./dist/index.js",


### PR DESCRIPTION
Bumps package version in package.json from 0.6.0 to 0.6.1. No other files are changed.