### PR TITLE
Fix missing zod enums for string unions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maktouch/kysely-zod-codegen",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "author": "Makara Sok",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/src/serializer/serializer.ts
+++ b/src/serializer/serializer.ts
@@ -89,6 +89,14 @@ export class Serializer {
     return undefined;
   }
 
+  isStringLiteralUnion(node: UnionExpressionNode): boolean {
+    if (!node.args.length) return false;
+
+    return node.args.every(
+      (arg) => arg.type === NodeType.LITERAL && typeof arg.value === 'string',
+    );
+  }
+
   isSerializableToZod(node: ExpressionNode, allNodes?: StatementNode[]): boolean {
     switch (node.type) {
       case NodeType.OBJECT_EXPRESSION:
@@ -114,6 +122,7 @@ export class Serializer {
       case NodeType.LITERAL:
         return true;
       case NodeType.UNION_EXPRESSION:
+        return this.isStringLiteralUnion(node as UnionExpressionNode);
       case NodeType.GENERIC_EXPRESSION:
       case NodeType.EXTENDS_CLAUSE:
       case NodeType.MAPPED_TYPE:


### PR DESCRIPTION
This PR fixes Zod generation for string-literal union aliases by allowing those unions to be serialized as Zod enums. It keeps non-literal unions (for example JSON helper unions) excluded from Zod emission. It also bumps the package version from 0.6.1 to 0.6.2. Built with 
> @maktouch/kysely-zod-codegen@0.6.2 build /Users/maktouch/conductor/workspaces/kysely-zod-codegen/yangon-v3
> tsc to verify the changes compile.